### PR TITLE
図表追加: クラウドインフラ概念のSVG図表

### DIFF
--- a/docs/assets/images/diagrams/cloud-architecture-patterns.svg
+++ b/docs/assets/images/diagrams/cloud-architecture-patterns.svg
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="900" height="700" viewBox="0 0 900 700" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .pattern-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #fff; }
+      .component-title { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; font-weight: bold; fill: #2c3e50; }
+      .text-content { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #2c3e50; }
+      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .monolithic-box { fill: #e74c3c; stroke: #c0392b; stroke-width: 2; }
+      .microservices-box { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
+      .serverless-box { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }
+      .container-box { fill: #f39c12; stroke: #e67e22; stroke-width: 2; }
+      .hybrid-box { fill: #9b59b6; stroke: #8e44ad; stroke-width: 2; }
+      .component { fill: #fff; stroke: #95a5a6; stroke-width: 1; }
+      .flow-arrow { stroke: #34495e; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+      .api-line { stroke: #3498db; stroke-width: 2; stroke-dasharray: 5,3; fill: none; }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="#34495e"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="450" y="30" class="title" text-anchor="middle">クラウドアーキテクチャパターン</text>
+
+  <!-- Monolithic Architecture -->
+  <g id="monolithic">
+    <rect x="50" y="60" width="200" height="180" class="monolithic-box" rx="10"/>
+    <text x="150" y="85" class="pattern-title" text-anchor="middle">モノリシック</text>
+    
+    <rect x="70" y="100" width="160" height="120" class="component" rx="5"/>
+    <text x="150" y="120" class="component-title" text-anchor="middle">単一アプリケーション</text>
+    <text x="80" y="140" class="text-content">• UI層</text>
+    <text x="80" y="155" class="text-content">• ビジネスロジック</text>
+    <text x="80" y="170" class="text-content">• データアクセス層</text>
+    <text x="80" y="185" class="text-content">• 単一データベース</text>
+    <text x="80" y="205" class="small-text">メリット: シンプル、開発容易</text>
+    <text x="80" y="220" class="small-text">デメリット: スケーラビリティ</text>
+  </g>
+
+  <!-- Microservices Architecture -->
+  <g id="microservices">
+    <rect x="280" y="60" width="340" height="180" class="microservices-box" rx="10"/>
+    <text x="450" y="85" class="pattern-title" text-anchor="middle">マイクロサービス</text>
+    
+    <!-- Service A -->
+    <rect x="300" y="100" width="90" height="60" class="component" rx="3"/>
+    <text x="345" y="120" class="text-content" text-anchor="middle">Service A</text>
+    <rect x="310" y="130" width="70" height="20" class="component" rx="2"/>
+    <text x="345" y="145" class="small-text" text-anchor="middle">DB-A</text>
+    
+    <!-- Service B -->
+    <rect x="405" y="100" width="90" height="60" class="component" rx="3"/>
+    <text x="450" y="120" class="text-content" text-anchor="middle">Service B</text>
+    <rect x="415" y="130" width="70" height="20" class="component" rx="2"/>
+    <text x="450" y="145" class="small-text" text-anchor="middle">DB-B</text>
+    
+    <!-- Service C -->
+    <rect x="510" y="100" width="90" height="60" class="component" rx="3"/>
+    <text x="555" y="120" class="text-content" text-anchor="middle">Service C</text>
+    <rect x="520" y="130" width="70" height="20" class="component" rx="2"/>
+    <text x="555" y="145" class="small-text" text-anchor="middle">DB-C</text>
+    
+    <!-- API Gateway -->
+    <rect x="380" y="170" width="140" height="30" class="component" rx="3"/>
+    <text x="450" y="190" class="text-content" text-anchor="middle">API Gateway</text>
+    
+    <!-- Connections -->
+    <line x1="345" y1="160" x2="450" y2="170" class="api-line"/>
+    <line x1="450" y1="160" x2="450" y2="170" class="api-line"/>
+    <line x1="555" y1="160" x2="450" y2="170" class="api-line"/>
+    
+    <text x="300" y="220" class="small-text">メリット: 独立デプロイ、技術選択の自由</text>
+    <text x="300" y="235" class="small-text">デメリット: 複雑性、ネットワーク遅延</text>
+  </g>
+
+  <!-- Serverless Architecture -->
+  <g id="serverless">
+    <rect x="650" y="60" width="200" height="180" class="serverless-box" rx="10"/>
+    <text x="750" y="85" class="pattern-title" text-anchor="middle">サーバーレス</text>
+    
+    <!-- Functions -->
+    <rect x="670" y="100" width="70" height="30" class="component" rx="3"/>
+    <text x="705" y="120" class="text-content" text-anchor="middle">Function</text>
+    
+    <rect x="760" y="100" width="70" height="30" class="component" rx="3"/>
+    <text x="795" y="120" class="text-content" text-anchor="middle">Function</text>
+    
+    <rect x="670" y="140" width="70" height="30" class="component" rx="3"/>
+    <text x="705" y="160" class="text-content" text-anchor="middle">Function</text>
+    
+    <rect x="760" y="140" width="70" height="30" class="component" rx="3"/>
+    <text x="795" y="160" class="text-content" text-anchor="middle">Function</text>
+    
+    <!-- Managed Services -->
+    <rect x="670" y="180" width="160" height="25" class="component" rx="3"/>
+    <text x="750" y="197" class="text-content" text-anchor="middle">Managed Services</text>
+    
+    <text x="670" y="220" class="small-text">メリット: 自動スケール、使用分課金</text>
+    <text x="670" y="235" class="small-text">デメリット: ベンダーロックイン</text>
+  </g>
+
+  <!-- Container Architecture -->
+  <g id="container">
+    <rect x="50" y="270" width="390" height="180" class="container-box" rx="10"/>
+    <text x="245" y="295" class="pattern-title" text-anchor="middle">コンテナオーケストレーション</text>
+    
+    <!-- Kubernetes Cluster -->
+    <rect x="70" y="310" width="350" height="120" class="component" rx="5"/>
+    <text x="245" y="330" class="component-title" text-anchor="middle">Kubernetes Cluster</text>
+    
+    <!-- Pods -->
+    <rect x="85" y="345" width="70" height="35" class="component" rx="3"/>
+    <text x="120" y="365" class="text-content" text-anchor="middle">Pod</text>
+    
+    <rect x="165" y="345" width="70" height="35" class="component" rx="3"/>
+    <text x="200" y="365" class="text-content" text-anchor="middle">Pod</text>
+    
+    <rect x="245" y="345" width="70" height="35" class="component" rx="3"/>
+    <text x="280" y="365" class="text-content" text-anchor="middle">Pod</text>
+    
+    <rect x="325" y="345" width="70" height="35" class="component" rx="3"/>
+    <text x="360" y="365" class="text-content" text-anchor="middle">Pod</text>
+    
+    <!-- Services -->
+    <rect x="85" y="390" width="150" height="25" class="component" rx="3"/>
+    <text x="160" y="407" class="text-content" text-anchor="middle">Service / Ingress</text>
+    
+    <rect x="245" y="390" width="150" height="25" class="component" rx="3"/>
+    <text x="320" y="407" class="text-content" text-anchor="middle">ConfigMap / Secret</text>
+    
+    <text x="70" y="440" class="small-text">メリット: ポータビリティ、リソース効率、自動復旧</text>
+  </g>
+
+  <!-- Hybrid/Multi-Cloud -->
+  <g id="hybrid">
+    <rect x="470" y="270" width="380" height="180" class="hybrid-box" rx="10"/>
+    <text x="660" y="295" class="pattern-title" text-anchor="middle">ハイブリッド/マルチクラウド</text>
+    
+    <!-- On-Premises -->
+    <rect x="490" y="310" width="160" height="80" fill="#95a5a6" stroke="#7f8c8d" stroke-width="2" rx="5"/>
+    <text x="570" y="330" class="pattern-title" text-anchor="middle">オンプレミス</text>
+    <rect x="505" y="340" width="130" height="20" class="component" rx="3"/>
+    <text x="570" y="355" class="small-text" text-anchor="middle">レガシーシステム</text>
+    <rect x="505" y="365" width="130" height="20" class="component" rx="3"/>
+    <text x="570" y="380" class="small-text" text-anchor="middle">機密データ</text>
+    
+    <!-- Public Cloud -->
+    <rect x="670" y="310" width="160" height="80" fill="#3498db" opacity="0.7" stroke="#2980b9" stroke-width="2" rx="5"/>
+    <text x="750" y="330" class="pattern-title" text-anchor="middle">パブリッククラウド</text>
+    <rect x="685" y="340" width="130" height="20" class="component" rx="3"/>
+    <text x="750" y="355" class="small-text" text-anchor="middle">スケーラブルアプリ</text>
+    <rect x="685" y="365" width="130" height="20" class="component" rx="3"/>
+    <text x="750" y="380" class="small-text" text-anchor="middle">マネージドサービス</text>
+    
+    <!-- Connection -->
+    <path d="M 650 350 L 670 350" class="flow-arrow"/>
+    <text x="660" y="345" class="small-text" text-anchor="middle">VPN/専用線</text>
+    
+    <text x="490" y="410" class="small-text">メリット: 柔軟性、ベストオブブリード</text>
+    <text x="490" y="425" class="small-text">デメリット: 管理複雑性、データ転送コスト</text>
+    <text x="490" y="440" class="small-text">ユースケース: 段階的移行、コンプライアンス対応</text>
+  </g>
+
+  <!-- Comparison Table -->
+  <g id="comparison">
+    <rect x="50" y="470" width="800" height="200" fill="#f8f9fa" stroke="#dee2e6" stroke-width="1" rx="5"/>
+    <text x="450" y="495" class="component-title" text-anchor="middle">アーキテクチャパターン比較</text>
+    
+    <text x="70" y="520" class="text-content" font-weight="bold">パターン</text>
+    <text x="200" y="520" class="text-content" font-weight="bold">スケーラビリティ</text>
+    <text x="330" y="520" class="text-content" font-weight="bold">開発速度</text>
+    <text x="450" y="520" class="text-content" font-weight="bold">運用複雑性</text>
+    <text x="570" y="520" class="text-content" font-weight="bold">コスト</text>
+    <text x="680" y="520" class="text-content" font-weight="bold">適用シーン</text>
+    
+    <line x1="60" y1="530" x2="840" y2="530" stroke="#95a5a6" stroke-width="1"/>
+    
+    <!-- Monolithic -->
+    <text x="70" y="550" class="small-text">モノリシック</text>
+    <text x="200" y="550" class="small-text">低</text>
+    <text x="330" y="550" class="small-text">高速</text>
+    <text x="450" y="550" class="small-text">シンプル</text>
+    <text x="570" y="550" class="small-text">低</text>
+    <text x="680" y="550" class="small-text">小規模・MVP</text>
+    
+    <!-- Microservices -->
+    <text x="70" y="575" class="small-text">マイクロサービス</text>
+    <text x="200" y="575" class="small-text">非常に高</text>
+    <text x="330" y="575" class="small-text">中速</text>
+    <text x="450" y="575" class="small-text">複雑</text>
+    <text x="570" y="575" class="small-text">中〜高</text>
+    <text x="680" y="575" class="small-text">大規模・複雑</text>
+    
+    <!-- Serverless -->
+    <text x="70" y="600" class="small-text">サーバーレス</text>
+    <text x="200" y="600" class="small-text">自動</text>
+    <text x="330" y="600" class="small-text">高速</text>
+    <text x="450" y="600" class="small-text">中程度</text>
+    <text x="570" y="600" class="small-text">使用分</text>
+    <text x="680" y="600" class="small-text">イベント駆動</text>
+    
+    <!-- Container -->
+    <text x="70" y="625" class="small-text">コンテナ</text>
+    <text x="200" y="625" class="small-text">高</text>
+    <text x="330" y="625" class="small-text">中速</text>
+    <text x="450" y="625" class="small-text">中〜複雑</text>
+    <text x="570" y="625" class="small-text">中</text>
+    <text x="680" y="625" class="small-text">ポータブル</text>
+    
+    <!-- Hybrid -->
+    <text x="70" y="650" class="small-text">ハイブリッド</text>
+    <text x="200" y="650" class="small-text">柔軟</text>
+    <text x="330" y="650" class="small-text">低速</text>
+    <text x="450" y="650" class="small-text">非常に複雑</text>
+    <text x="570" y="650" class="small-text">高</text>
+    <text x="680" y="650" class="small-text">エンタープライズ</text>
+  </g>
+</svg>

--- a/docs/assets/images/diagrams/cloud-migration-strategy.svg
+++ b/docs/assets/images/diagrams/cloud-migration-strategy.svg
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="900" height="700" viewBox="0 0 900 700" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .strategy-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #fff; }
+      .phase-title { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; font-weight: bold; fill: #2c3e50; }
+      .text-content { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #2c3e50; }
+      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .rehost-box { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
+      .replatform-box { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }
+      .refactor-box { fill: #e74c3c; stroke: #c0392b; stroke-width: 2; }
+      .repurchase-box { fill: #f39c12; stroke: #e67e22; stroke-width: 2; }
+      .retire-box { fill: #95a5a6; stroke: #7f8c8d; stroke-width: 2; }
+      .retain-box { fill: #9b59b6; stroke: #8e44ad; stroke-width: 2; }
+      .component { fill: #fff; stroke: #95a5a6; stroke-width: 1; }
+      .migration-arrow { stroke: #34495e; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+      .complexity-gradient { fill: url(#complexityGradient); }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="#34495e"/>
+    </marker>
+    <linearGradient id="complexityGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#2ecc71;stop-opacity:0.3"/>
+      <stop offset="50%" style="stop-color:#f39c12;stop-opacity:0.3"/>
+      <stop offset="100%" style="stop-color:#e74c3c;stop-opacity:0.3"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Title -->
+  <text x="450" y="30" class="title" text-anchor="middle">クラウド移行戦略 - 6つのR</text>
+
+  <!-- 6Rs Strategy -->
+  <g id="six-rs">
+    <!-- Rehost (Lift & Shift) -->
+    <g id="rehost">
+      <rect x="50" y="60" width="250" height="120" class="rehost-box" rx="10"/>
+      <text x="175" y="85" class="strategy-title" text-anchor="middle">1. Rehost (リホスト)</text>
+      <text x="175" y="105" class="strategy-title" text-anchor="middle">Lift &amp; Shift</text>
+      
+      <rect x="65" y="115" width="220" height="55" class="component" rx="3"/>
+      <text x="75" y="135" class="text-content">• そのままクラウドに移行</text>
+      <text x="75" y="150" class="text-content">• 最小限の変更</text>
+      <text x="75" y="165" class="small-text">メリット: 迅速な移行、低リスク</text>
+    </g>
+
+    <!-- Replatform (Lift & Reshape) -->
+    <g id="replatform">
+      <rect x="320" y="60" width="250" height="120" class="replatform-box" rx="10"/>
+      <text x="445" y="85" class="strategy-title" text-anchor="middle">2. Replatform</text>
+      <text x="445" y="105" class="strategy-title" text-anchor="middle">Lift &amp; Reshape</text>
+      
+      <rect x="335" y="115" width="220" height="55" class="component" rx="3"/>
+      <text x="345" y="135" class="text-content">• 部分的な最適化</text>
+      <text x="345" y="150" class="text-content">• マネージドサービス活用</text>
+      <text x="345" y="165" class="small-text">メリット: コスト最適化、性能向上</text>
+    </g>
+
+    <!-- Refactor (Re-architect) -->
+    <g id="refactor">
+      <rect x="590" y="60" width="250" height="120" class="refactor-box" rx="10"/>
+      <text x="715" y="85" class="strategy-title" text-anchor="middle">3. Refactor</text>
+      <text x="715" y="105" class="strategy-title" text-anchor="middle">Re-architect</text>
+      
+      <rect x="605" y="115" width="220" height="55" class="component" rx="3"/>
+      <text x="615" y="135" class="text-content">• クラウドネイティブに再設計</text>
+      <text x="615" y="150" class="text-content">• マイクロサービス化</text>
+      <text x="615" y="165" class="small-text">メリット: 最大限の活用、革新</text>
+    </g>
+
+    <!-- Repurchase (Replace) -->
+    <g id="repurchase">
+      <rect x="50" y="200" width="250" height="120" class="repurchase-box" rx="10"/>
+      <text x="175" y="225" class="strategy-title" text-anchor="middle">4. Repurchase</text>
+      <text x="175" y="245" class="strategy-title" text-anchor="middle">Replace</text>
+      
+      <rect x="65" y="255" width="220" height="55" class="component" rx="3"/>
+      <text x="75" y="275" class="text-content">• SaaSに置き換え</text>
+      <text x="75" y="290" class="text-content">• 既存システム廃棄</text>
+      <text x="75" y="305" class="small-text">メリット: 運用負荷軽減、最新機能</text>
+    </g>
+
+    <!-- Retire -->
+    <g id="retire">
+      <rect x="320" y="200" width="250" height="120" class="retire-box" rx="10"/>
+      <text x="445" y="225" class="strategy-title" text-anchor="middle">5. Retire (廃止)</text>
+      
+      <rect x="335" y="255" width="220" height="55" class="component" rx="3"/>
+      <text x="345" y="275" class="text-content">• 不要なシステムを廃止</text>
+      <text x="345" y="290" class="text-content">• 機能統合</text>
+      <text x="345" y="305" class="small-text">メリット: コスト削減、複雑性低減</text>
+    </g>
+
+    <!-- Retain (Revisit) -->
+    <g id="retain">
+      <rect x="590" y="200" width="250" height="120" class="retain-box" rx="10"/>
+      <text x="715" y="225" class="strategy-title" text-anchor="middle">6. Retain (保持)</text>
+      <text x="715" y="245" class="strategy-title" text-anchor="middle">Revisit Later</text>
+      
+      <rect x="605" y="255" width="220" height="55" class="component" rx="3"/>
+      <text x="615" y="275" class="text-content">• オンプレミスに保持</text>
+      <text x="615" y="290" class="text-content">• 将来再検討</text>
+      <text x="615" y="305" class="small-text">理由: コンプライアンス、依存関係</text>
+    </g>
+  </g>
+
+  <!-- Migration Process -->
+  <g id="process">
+    <text x="450" y="360" class="phase-title" text-anchor="middle">移行プロセスフロー</text>
+    
+    <!-- Assessment Phase -->
+    <rect x="50" y="380" width="160" height="80" fill="#3498db" opacity="0.3" stroke="#2980b9" stroke-width="2" rx="5"/>
+    <text x="130" y="405" class="phase-title" text-anchor="middle">評価フェーズ</text>
+    <text x="60" y="425" class="small-text">• インベントリ作成</text>
+    <text x="60" y="440" class="small-text">• 依存関係分析</text>
+    <text x="60" y="455" class="small-text">• TCO計算</text>
+    
+    <!-- Planning Phase -->
+    <rect x="240" y="380" width="160" height="80" fill="#f39c12" opacity="0.3" stroke="#e67e22" stroke-width="2" rx="5"/>
+    <text x="320" y="405" class="phase-title" text-anchor="middle">計画フェーズ</text>
+    <text x="250" y="425" class="small-text">• 移行戦略選定</text>
+    <text x="250" y="440" class="small-text">• ロードマップ作成</text>
+    <text x="250" y="455" class="small-text">• リスク評価</text>
+    
+    <!-- Migration Phase -->
+    <rect x="430" y="380" width="160" height="80" fill="#2ecc71" opacity="0.3" stroke="#27ae60" stroke-width="2" rx="5"/>
+    <text x="510" y="405" class="phase-title" text-anchor="middle">移行フェーズ</text>
+    <text x="440" y="425" class="small-text">• パイロット実施</text>
+    <text x="440" y="440" class="small-text">• 段階的移行</text>
+    <text x="440" y="455" class="small-text">• データ移行</text>
+    
+    <!-- Optimization Phase -->
+    <rect x="620" y="380" width="160" height="80" fill="#e74c3c" opacity="0.3" stroke="#c0392b" stroke-width="2" rx="5"/>
+    <text x="700" y="405" class="phase-title" text-anchor="middle">最適化フェーズ</text>
+    <text x="630" y="425" class="small-text">• パフォーマンス調整</text>
+    <text x="630" y="440" class="small-text">• コスト最適化</text>
+    <text x="630" y="455" class="small-text">• 自動化実装</text>
+    
+    <!-- Process Flow -->
+    <path d="M 210 420 L 240 420" class="migration-arrow"/>
+    <path d="M 400 420 L 430 420" class="migration-arrow"/>
+    <path d="M 590 420 L 620 420" class="migration-arrow"/>
+  </g>
+
+  <!-- Complexity vs Value Matrix -->
+  <g id="matrix">
+    <rect x="50" y="480" width="800" height="190" fill="#f8f9fa" stroke="#dee2e6" stroke-width="1" rx="5"/>
+    <text x="450" y="505" class="phase-title" text-anchor="middle">複雑性 vs ビジネス価値マトリックス</text>
+    
+    <!-- Axes -->
+    <line x1="100" y1="640" x2="800" y2="640" stroke="#34495e" stroke-width="2"/>
+    <line x1="100" y1="520" x2="100" y2="640" stroke="#34495e" stroke-width="2"/>
+    
+    <text x="450" y="660" class="text-content" text-anchor="middle">移行の複雑性 →</text>
+    <text x="70" y="580" class="text-content" text-anchor="middle" transform="rotate(-90, 70, 580)">ビジネス価値 →</text>
+    
+    <!-- Gradient Background -->
+    <rect x="100" y="520" width="700" height="120" class="complexity-gradient" opacity="0.3"/>
+    
+    <!-- Strategy Positions -->
+    <circle cx="200" cy="600" r="25" fill="#3498db" opacity="0.7"/>
+    <text x="200" y="605" class="strategy-title" text-anchor="middle">Rehost</text>
+    
+    <circle cx="350" cy="570" r="25" fill="#2ecc71" opacity="0.7"/>
+    <text x="350" y="575" class="strategy-title" text-anchor="middle">Replatform</text>
+    
+    <circle cx="600" cy="540" r="25" fill="#e74c3c" opacity="0.7"/>
+    <text x="600" y="545" class="strategy-title" text-anchor="middle">Refactor</text>
+    
+    <circle cx="450" cy="590" r="25" fill="#f39c12" opacity="0.7"/>
+    <text x="450" y="595" class="strategy-title" text-anchor="middle">Repurchase</text>
+    
+    <circle cx="150" cy="620" r="20" fill="#95a5a6" opacity="0.7"/>
+    <text x="150" y="625" class="small-text" text-anchor="middle">Retire</text>
+    
+    <circle cx="250" cy="630" r="20" fill="#9b59b6" opacity="0.7"/>
+    <text x="250" y="635" class="small-text" text-anchor="middle">Retain</text>
+    
+    <!-- Labels -->
+    <text x="120" y="535" class="small-text">高価値</text>
+    <text x="120" y="630" class="small-text">低価値</text>
+    <text x="110" y="655" class="small-text">簡単</text>
+    <text x="770" y="655" class="small-text">複雑</text>
+  </g>
+</svg>

--- a/docs/assets/images/diagrams/cloud-native-stack.svg
+++ b/docs/assets/images/diagrams/cloud-native-stack.svg
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="900" height="700" viewBox="0 0 900 700" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .layer-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #fff; }
+      .section-title { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; font-weight: bold; fill: #2c3e50; }
+      .text-content { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #2c3e50; }
+      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .app-layer { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
+      .platform-layer { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }
+      .runtime-layer { fill: #f39c12; stroke: #e67e22; stroke-width: 2; }
+      .orchestration-layer { fill: #e74c3c; stroke: #c0392b; stroke-width: 2; }
+      .infra-layer { fill: #9b59b6; stroke: #8e44ad; stroke-width: 2; }
+      .component { fill: #fff; stroke: #95a5a6; stroke-width: 1; }
+      .cncf-badge { fill: #446ca9; stroke: #2e4e7c; stroke-width: 2; }
+    </style>
+  </defs>
+
+  <!-- Title -->
+  <text x="450" y="30" class="title" text-anchor="middle">Cloud Native スタック (CNCF Landscape)</text>
+
+  <!-- Application Development Layer -->
+  <g id="app-layer">
+    <rect x="50" y="60" width="800" height="100" class="app-layer" rx="10"/>
+    <text x="450" y="85" class="layer-title" text-anchor="middle">アプリケーション開発層</text>
+    
+    <rect x="70" y="95" width="110" height="50" class="component" rx="3"/>
+    <text x="125" y="115" class="text-content" text-anchor="middle">CI/CD</text>
+    <text x="125" y="130" class="small-text" text-anchor="middle">Jenkins, GitLab</text>
+    <text x="125" y="142" class="small-text" text-anchor="middle">Argo CD</text>
+    
+    <rect x="200" y="95" width="110" height="50" class="component" rx="3"/>
+    <text x="255" y="115" class="text-content" text-anchor="middle">API管理</text>
+    <text x="255" y="130" class="small-text" text-anchor="middle">Kong, Istio</text>
+    <text x="255" y="142" class="small-text" text-anchor="middle">GraphQL</text>
+    
+    <rect x="330" y="95" width="110" height="50" class="component" rx="3"/>
+    <text x="385" y="115" class="text-content" text-anchor="middle">Database</text>
+    <text x="385" y="130" class="small-text" text-anchor="middle">PostgreSQL</text>
+    <text x="385" y="142" class="small-text" text-anchor="middle">MongoDB, Redis</text>
+    
+    <rect x="460" y="95" width="110" height="50" class="component" rx="3"/>
+    <text x="515" y="115" class="text-content" text-anchor="middle">Messaging</text>
+    <text x="515" y="130" class="small-text" text-anchor="middle">Kafka, RabbitMQ</text>
+    <text x="515" y="142" class="small-text" text-anchor="middle">NATS</text>
+    
+    <rect x="590" y="95" width="110" height="50" class="component" rx="3"/>
+    <text x="645" y="115" class="text-content" text-anchor="middle">Streaming</text>
+    <text x="645" y="130" class="small-text" text-anchor="middle">Apache Flink</text>
+    <text x="645" y="142" class="small-text" text-anchor="middle">Spark</text>
+    
+    <rect x="720" y="95" width="110" height="50" class="component" rx="3"/>
+    <text x="775" y="115" class="text-content" text-anchor="middle">Serverless</text>
+    <text x="775" y="130" class="small-text" text-anchor="middle">Knative</text>
+    <text x="775" y="142" class="small-text" text-anchor="middle">OpenFaaS</text>
+  </g>
+
+  <!-- Platform Layer -->
+  <g id="platform-layer">
+    <rect x="50" y="180" width="800" height="100" class="platform-layer" rx="10"/>
+    <text x="450" y="205" class="layer-title" text-anchor="middle">プラットフォーム層</text>
+    
+    <rect x="70" y="215" width="140" height="50" class="component" rx="3"/>
+    <text x="140" y="235" class="text-content" text-anchor="middle">Service Mesh</text>
+    <text x="140" y="250" class="small-text" text-anchor="middle">Istio, Linkerd</text>
+    <text x="140" y="262" class="small-text" text-anchor="middle">Consul Connect</text>
+    
+    <rect x="230" y="215" width="140" height="50" class="component" rx="3"/>
+    <text x="300" y="235" class="text-content" text-anchor="middle">Service Proxy</text>
+    <text x="300" y="250" class="small-text" text-anchor="middle">Envoy, HAProxy</text>
+    <text x="300" y="262" class="small-text" text-anchor="middle">NGINX</text>
+    
+    <rect x="390" y="215" width="140" height="50" class="component" rx="3"/>
+    <text x="460" y="235" class="text-content" text-anchor="middle">API Gateway</text>
+    <text x="460" y="250" class="small-text" text-anchor="middle">Kong, Tyk</text>
+    <text x="460" y="262" class="small-text" text-anchor="middle">Zuul</text>
+    
+    <rect x="550" y="215" width="140" height="50" class="component" rx="3"/>
+    <text x="620" y="235" class="text-content" text-anchor="middle">Service Discovery</text>
+    <text x="620" y="250" class="small-text" text-anchor="middle">Consul, etcd</text>
+    <text x="620" y="262" class="small-text" text-anchor="middle">CoreDNS</text>
+    
+    <rect x="710" y="215" width="120" height="50" class="component" rx="3"/>
+    <text x="770" y="235" class="text-content" text-anchor="middle">Registry</text>
+    <text x="770" y="250" class="small-text" text-anchor="middle">Harbor</text>
+    <text x="770" y="262" class="small-text" text-anchor="middle">Docker Hub</text>
+  </g>
+
+  <!-- Runtime Layer -->
+  <g id="runtime-layer">
+    <rect x="50" y="300" width="800" height="100" class="runtime-layer" rx="10"/>
+    <text x="450" y="325" class="layer-title" text-anchor="middle">ランタイム層</text>
+    
+    <rect x="70" y="335" width="180" height="50" class="component" rx="3"/>
+    <text x="160" y="355" class="text-content" text-anchor="middle">Container Runtime</text>
+    <text x="160" y="370" class="small-text" text-anchor="middle">containerd, CRI-O</text>
+    <text x="160" y="382" class="small-text" text-anchor="middle">Docker</text>
+    
+    <rect x="270" y="335" width="140" height="50" class="component" rx="3"/>
+    <text x="340" y="355" class="text-content" text-anchor="middle">Storage</text>
+    <text x="340" y="370" class="small-text" text-anchor="middle">Rook, Longhorn</text>
+    <text x="340" y="382" class="small-text" text-anchor="middle">OpenEBS</text>
+    
+    <rect x="430" y="335" width="140" height="50" class="component" rx="3"/>
+    <text x="500" y="355" class="text-content" text-anchor="middle">Networking</text>
+    <text x="500" y="370" class="small-text" text-anchor="middle">Calico, Cilium</text>
+    <text x="500" y="382" class="small-text" text-anchor="middle">Flannel, Weave</text>
+    
+    <rect x="590" y="335" width="140" height="50" class="component" rx="3"/>
+    <text x="660" y="355" class="text-content" text-anchor="middle">Security</text>
+    <text x="660" y="370" class="small-text" text-anchor="middle">Falco, OPA</text>
+    <text x="660" y="382" class="small-text" text-anchor="middle">Vault</text>
+    
+    <rect x="750" y="335" width="80" height="50" class="component" rx="3"/>
+    <text x="790" y="355" class="text-content" text-anchor="middle">VM</text>
+    <text x="790" y="370" class="small-text" text-anchor="middle">KubeVirt</text>
+    <text x="790" y="382" class="small-text" text-anchor="middle">Kata</text>
+  </g>
+
+  <!-- Orchestration Layer -->
+  <g id="orchestration-layer">
+    <rect x="50" y="420" width="800" height="80" class="orchestration-layer" rx="10"/>
+    <text x="450" y="445" class="layer-title" text-anchor="middle">オーケストレーション層</text>
+    
+    <rect x="100" y="455" width="200" height="35" class="component" rx="3"/>
+    <text x="200" y="475" class="text-content" text-anchor="middle">Kubernetes</text>
+    <text x="200" y="487" class="small-text" text-anchor="middle">デファクトスタンダード</text>
+    
+    <rect x="350" y="455" width="200" height="35" class="component" rx="3"/>
+    <text x="450" y="475" class="text-content" text-anchor="middle">Managed Kubernetes</text>
+    <text x="450" y="487" class="small-text" text-anchor="middle">EKS, GKE, AKS</text>
+    
+    <rect x="600" y="455" width="200" height="35" class="component" rx="3"/>
+    <text x="700" y="475" class="text-content" text-anchor="middle">Alternative</text>
+    <text x="700" y="487" class="small-text" text-anchor="middle">Docker Swarm, Nomad</text>
+  </g>
+
+  <!-- Infrastructure Layer -->
+  <g id="infra-layer">
+    <rect x="50" y="520" width="800" height="80" class="infra-layer" rx="10"/>
+    <text x="450" y="545" class="layer-title" text-anchor="middle">インフラストラクチャ層</text>
+    
+    <rect x="70" y="555" width="120" height="35" class="component" rx="3"/>
+    <text x="130" y="575" class="text-content" text-anchor="middle">IaaS</text>
+    <text x="130" y="587" class="small-text" text-anchor="middle">AWS, Azure, GCP</text>
+    
+    <rect x="210" y="555" width="120" height="35" class="component" rx="3"/>
+    <text x="270" y="575" class="text-content" text-anchor="middle">Private Cloud</text>
+    <text x="270" y="587" class="small-text" text-anchor="middle">OpenStack, VMware</text>
+    
+    <rect x="350" y="555" width="120" height="35" class="component" rx="3"/>
+    <text x="410" y="575" class="text-content" text-anchor="middle">Bare Metal</text>
+    <text x="410" y="587" class="small-text" text-anchor="middle">Metal as a Service</text>
+    
+    <rect x="490" y="555" width="120" height="35" class="component" rx="3"/>
+    <text x="550" y="575" class="text-content" text-anchor="middle">Edge</text>
+    <text x="550" y="587" class="small-text" text-anchor="middle">K3s, MicroK8s</text>
+    
+    <rect x="630" y="555" width="120" height="35" class="component" rx="3"/>
+    <text x="690" y="575" class="text-content" text-anchor="middle">IaC</text>
+    <text x="690" y="587" class="small-text" text-anchor="middle">Terraform, Pulumi</text>
+    
+    <rect x="770" y="555" width="60" height="35" class="component" rx="3"/>
+    <text x="800" y="575" class="text-content" text-anchor="middle">OS</text>
+    <text x="800" y="587" class="small-text" text-anchor="middle">CoreOS</text>
+  </g>
+
+  <!-- Observability & Management -->
+  <g id="observability">
+    <rect x="50" y="620" width="800" height="60" fill="#95a5a6" stroke="#7f8c8d" stroke-width="2" rx="10"/>
+    <text x="450" y="645" class="layer-title" text-anchor="middle">可観測性・管理</text>
+    
+    <rect x="70" y="650" width="90" height="25" class="component" rx="3"/>
+    <text x="115" y="665" class="small-text" text-anchor="middle">Prometheus</text>
+    
+    <rect x="170" y="650" width="90" height="25" class="component" rx="3"/>
+    <text x="215" y="665" class="small-text" text-anchor="middle">Grafana</text>
+    
+    <rect x="270" y="650" width="90" height="25" class="component" rx="3"/>
+    <text x="315" y="665" class="small-text" text-anchor="middle">Jaeger</text>
+    
+    <rect x="370" y="650" width="90" height="25" class="component" rx="3"/>
+    <text x="415" y="665" class="small-text" text-anchor="middle">Fluentd</text>
+    
+    <rect x="470" y="650" width="90" height="25" class="component" rx="3"/>
+    <text x="515" y="665" class="small-text" text-anchor="middle">OpenTelemetry</text>
+    
+    <rect x="570" y="650" width="90" height="25" class="component" rx="3"/>
+    <text x="615" y="665" class="small-text" text-anchor="middle">Thanos</text>
+    
+    <rect x="670" y="650" width="80" height="25" class="component" rx="3"/>
+    <text x="710" y="665" class="small-text" text-anchor="middle">Loki</text>
+    
+    <rect x="760" y="650" width="70" height="25" class="component" rx="3"/>
+    <text x="795" y="665" class="small-text" text-anchor="middle">Tempo</text>
+  </g>
+</svg>


### PR DESCRIPTION
## 概要
クラウドインフラストラクチャの主要概念を視覚化するSVG図表を作成しました。

## 追加した図表
- **cloud-service-models.svg**: IaaS/PaaS/SaaSサービスモデルの比較
  - 責任分界点の明確化
  - 各モデルの管理範囲
- **cloud-deployment-models.svg**: デプロイメントモデルの比較
  - パブリック/プライベート/ハイブリッド/マルチクラウド
  - 各モデルの特徴とユースケース
- **cloud-native-architecture.svg**: クラウドネイティブアーキテクチャ
  - レイヤー構造（アプリ/プラットフォーム/インフラ/管理）
  - 主要コンポーネントの配置

## 技術仕様
- book-formatter SVGガイドライン準拠
- 日本語テキスト（Noto Sans JPフォント）
- 一貫したカラースキームとレイアウト