### PR TITLE
docs: add bottom navigation to root

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,3 +49,4 @@ Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
 **著者**: 株式会社アイティードゥ  
 **Email**: knowledge@itdo.jp  
 **GitHub**: [@itdojp](https://github.com/itdojp)
+{% include page-navigation.html %}


### PR DESCRIPTION
Add bottom navigation include to docs/index.md so the root page shows prev/next/home controls.