### PR TITLE
fix: 付録ページのtitleを見出しに整合

### DIFF
--- a/docs/appendices/index.md
+++ b/docs/appendices/index.md
@@ -1,7 +1,7 @@
 ---
 layout: book
 order: 14
-title: "付録: リソースとツール"
+title: "付録：参考資料"
 ---
 
 # 付録：参考資料


### PR DESCRIPTION
付録ページ（`docs/appendices/index.md`）で front matter の `title` とH1が不一致だったため、H1（`付録：参考資料`）に合わせて整合しました。\n\n- 変更はメタ情報のみで、本文の意味変更はありません。