### PR TITLE
fix(docs): 第5章のコードフェンス表示崩れを修正

### DIFF
--- a/docs/chapter-chapter05/index.md
+++ b/docs/chapter-chapter05/index.md
@@ -22,7 +22,7 @@ title: "第5章：ネットワークの設計と実装"
 
 ネットワーク設計の誤りは、後から修正することが極めて困難です。IPアドレス範囲の変更、サブネットの再構成、ルーティングの見直しは、しばしばダウンタイムを伴う大規模な作業となります。初期設計の重要性は、いくら強調してもし過ぎることはありません。
 
-`python
+```python
 class VPCDesignPrinciples:
     """
     VPC設計の原則と実装
@@ -85,7 +85,7 @@ class VPCDesignPrinciples:
             'good_design': good_design,
             'recommendation': '初期設計に十分な時間を投資することが重要'
         }
-`
+```
 
 ### 階層型ネットワークアーキテクチャ
 
@@ -93,7 +93,7 @@ class VPCDesignPrinciples:
 
 従来のネットワーク設計では、プレゼンテーション層、アプリケーション層、データ層という三層構造が一般的でした。クラウドでは、この概念をセキュリティゾーンとして再解釈します：
 
-`python
+```python
 class ThreeTierArchitecture:
     """
     三層アーキテクチャの実装
@@ -230,7 +230,7 @@ class ThreeTierArchitecture:
             'subnets': subnets,
             'architecture': subnet_config
         }
-`
+```
 
 ### IPアドレス設計の芸術と科学
 
@@ -238,7 +238,7 @@ class ThreeTierArchitecture:
 
 IPアドレス空間の設計は、現在のニーズと将来の拡張性のバランスを取る必要があります：
 
-`python
+```python
 class IPAddressPlanning:
     """
     IPアドレス計画の実装
@@ -367,7 +367,7 @@ class IPAddressPlanning:
             'has_conflicts': False,
             'message': 'No conflicts detected'
         }
-`
+```
 
 ### マルチAZ設計の実装
 
@@ -375,7 +375,7 @@ class IPAddressPlanning:
 
 各アベイラビリティゾーンに同じサブネット構造を複製することで、管理の複雑さを軽減し、自動化を容易にします：
 
-`python
+```python
 class MultiAZDesign:
     """
     マルチAZ設計の実装
@@ -474,7 +474,7 @@ class MultiAZDesign:
             'route_table_design': route_table_design,
             'availability': availability_calculation
         }
-`
+```
 
 ### セキュリティを考慮したセグメンテーション
 
@@ -482,7 +482,7 @@ class MultiAZDesign:
 
 ゼロトラストセキュリティモデルでは、ネットワーク内部でも信頼しない原則を適用します：
 
-`python
+```python
 class SecuritySegmentation:
     """
     セキュリティセグメンテーションの実装
@@ -682,7 +682,7 @@ class SecuritySegmentation:
             'principles': zero_trust_principles,
             'privatelink': privatelink_design
         }
-`
+```
 
 ### 拡張性を考慮した設計
 
@@ -690,7 +690,7 @@ class SecuritySegmentation:
 
 設計時に考慮すべき将来シナリオ：
 
-`python
+```python
 class ScalableNetworkDesign:
     """
     拡張可能なネットワーク設計
@@ -808,11 +808,11 @@ class ScalableNetworkDesign:
             'transit_gateway': transit_gateway_design,
             'cidr_plan': cidr_reservation_plan
         }
-`
+```
 
 ### VPC設計のベストプラクティス実装
 
-`python
+```python
 class VPCBestPractices:
     """
     VPC設計のベストプラクティス
@@ -942,7 +942,7 @@ class VPCBestPractices:
             'template_example': vpc_template,
             'validation_command': 'aws ec2 describe-vpc-attribute --vpc-id vpc-xxx --attribute enableDnsSupport'
         }
-`
+```
 
 ## 5.2 ルーティングとVPN接続
 
@@ -954,7 +954,7 @@ class VPCBestPractices:
 
 各サブネットは、トラフィックの宛先を決定するルートテーブルに関連付けられます。このシンプルな仕組みが、複雑なネットワークトポロジーの実現を可能にします。
 
-`python
+```python
 class CloudRouting:
     """
     クラウドルーティングの実装
@@ -1082,7 +1082,7 @@ class CloudRouting:
             'peering': peering_routing,
             'transit_gateway': transit_gateway_routing
         }
-`
+```
 
 ### ハイブリッドクラウド接続の実現
 
@@ -1090,7 +1090,7 @@ class CloudRouting:
 
 多くの組織にとって、VPNは最初のハイブリッドクラウド接続手段となります。その魅力は、既存のインターネット接続を利用できる手軽さと、比較的低いコストです。
 
-`python
+```python
 class HybridCloudConnection:
     """
     ハイブリッドクラウド接続の実装
@@ -1254,7 +1254,7 @@ class HybridCloudConnection:
             'configuration_example': bgp_configuration,
             'best_practices': bgp_best_practices
         }
-`
+```
 
 ### 専用接続の価値
 
@@ -1262,7 +1262,7 @@ class HybridCloudConnection:
 
 専用接続サービスは、インターネットを経由しない、プライベートな接続を提供します：
 
-`python
+```python
 class DedicatedConnection:
     """
     専用接続の実装
@@ -1402,7 +1402,7 @@ class DedicatedConnection:
         }
         
         return hybrid_patterns
-`
+```
 
 ### トランジットゲートウェイとハブ＆スポーク
 
@@ -1410,7 +1410,7 @@ class DedicatedConnection:
 
 複数のVPCやオンプレミスネットワークを接続する場合、メッシュ型の接続は管理が複雑になります。トランジットゲートウェイは、中央ハブとして機能し、接続を簡素化します。
 
-`python
+```python
 class TransitGatewayArchitecture:
     """
     Transit Gatewayアーキテクチャの実装
@@ -1543,13 +1543,13 @@ class TransitGatewayArchitecture:
         }
         
         return segmentation_strategy
-`
+```
 
 ### VPNのパフォーマンスとトラブルシューティング
 
 **パフォーマンスの最適化**
 
-`python
+```python
 class VPNOptimization:
     """
     VPNパフォーマンスの最適化
@@ -1693,7 +1693,7 @@ class VPNOptimization:
         }
         
         return troubleshooting_guide
-`
+```
 
 ## 5.3 ロードバランサーの種類と活用
 
@@ -1705,7 +1705,7 @@ class VPNOptimization:
 
 現代のアプリケーションは、以下を実現する必要があります：
 
-`python
+```python
 class LoadBalancerEvolution:
     """
     ロードバランサーの進化と重要性
@@ -1801,7 +1801,7 @@ class LoadBalancerEvolution:
             'functions': critical_functions,
             'evolution': evolution_timeline
         }
-`
+```
 
 ### レイヤー4とレイヤー7の使い分け
 
@@ -1809,7 +1809,7 @@ class LoadBalancerEvolution:
 
 トランスポート層（TCP/UDP）で動作し、高速で低レイテンシ：
 
-`python
+```python
 class NetworkLoadBalancer:
     """
     ネットワークロードバランサー（NLB）の実装
@@ -1939,13 +1939,13 @@ class NetworkLoadBalancer:
         }
         
         return proxy_protocol_policy
-`
+```
 
 **アプリケーションロードバランサー（L7）**
 
 HTTPレイヤーで動作し、高度なルーティング機能：
 
-`python
+```python
 class ApplicationLoadBalancer:
     """
     アプリケーションロードバランサー（ALB）の実装
@@ -2167,7 +2167,7 @@ class ApplicationLoadBalancer:
             'waf': waf_integration,
             'lambda': lambda_target
         }
-`
+```
 
 ### 高度なロードバランシング機能
 
@@ -2175,7 +2175,7 @@ class ApplicationLoadBalancer:
 
 特定のクライアントを同じバックエンドサーバーに固定：
 
-`python
+```python
 class AdvancedLoadBalancing:
     """
     高度なロードバランシング機能
@@ -2371,13 +2371,13 @@ class AdvancedLoadBalancing:
         }
         
         return best_practices
-`
+```
 
 ### グローバルロードバランシング
 
 **地理的分散とレイテンシ最適化**
 
-`python
+```python
 class GlobalLoadBalancing:
     """
     グローバルロードバランシングの実装
@@ -2518,13 +2518,13 @@ class GlobalLoadBalancing:
             'geolocation': geolocation_policy,
             'multi_cdn': multi_cdn_strategy
         }
-`
+```
 
 ### ロードバランサーのセキュリティ
 
 **SSL/TLS終端とオフロード**
 
-`python
+```python
 class LoadBalancerSecurity:
     """
     ロードバランサーのセキュリティ実装
@@ -2681,11 +2681,11 @@ class LoadBalancerSecurity:
             'web_acl_arn': web_acl['Summary']['ARN'],
             'custom_rules': custom_rules
         }
-`
+```
 
 **ゼロダウンタイムデプロイメント**
 
-`python
+```python
 class ZeroDowntimeDeployment:
     """
     ゼロダウンタイムデプロイメントの実装
@@ -2775,7 +2775,7 @@ class ZeroDowntimeDeployment:
         }
         
         return rolling_strategy
-`
+```
 
 ## 5.4 DNSサービス（Route 53, Azure DNS, Cloud DNS）
 
@@ -2787,7 +2787,7 @@ DNSは「インターネットの電話帳」という単純な説明を超え�
 
 従来のDNSサーバーと異なり、クラウドのマネージドDNSは：
 
-`python
+```python
 class CloudNativeDNS:
     """
     クラウドネイティブDNSの実装
@@ -2887,13 +2887,13 @@ class CloudNativeDNS:
             'private_zone_id': private_zone['HostedZone']['Id'],
             'design': zone_design
         }
-`
+```
 
 ### レコードタイプとその活用
 
 **基本的なレコードタイプ**
 
-`python
+```python
 class DNSRecordManagement:
     """
     DNSレコード管理の実装
@@ -3058,13 +3058,13 @@ class DNSRecordManagement:
             ],
             'example': service_discovery
         }
-`
+```
 
 ### 高度なルーティングポリシー
 
 **地理的ルーティング**
 
-`python
+```python
 class AdvancedDNSRouting:
     """
     高度なDNSルーティングの実装
@@ -3277,13 +3277,13 @@ class AdvancedDNSRouting:
             'health_check': health_check_config,
             'strategy': failover_strategy
         }
-`
+```
 
 ### DNSセキュリティ
 
 **DNSSEC（DNS Security Extensions）**
 
-`python
+```python
 class DNSSecurity:
     """
     DNSセキュリティの実装
@@ -3364,13 +3364,13 @@ class DNSSecurity:
             'firewall_rules': dns_firewall_rules,
             'rate_limiting': rate_limiting
         }
-`
+```
 
 ### 障害対策とフェイルオーバー
 
 **ヘルスチェックとの連携**
 
-`python
+```python
 class DNSResilience:
     """
     DNS障害対策の実装
@@ -3477,7 +3477,7 @@ class DNSResilience:
             'architecture': failover_architecture,
             'procedures': failover_procedures
         }
-`
+```
 
 ## 5.5 CDN（Content Delivery Network）の利用
 
@@ -3489,7 +3489,7 @@ CDNは単なるキャッシュサーバーの集合ではありません。そ�
 
 CDNは、計算とストレージをユーザーの近くに配置するエッジコンピューティングの先駆けです：
 
-`python
+```python
 class CDNFundamentals:
     """
     CDNの基本概念と価値
@@ -3577,13 +3577,13 @@ class CDNFundamentals:
         }
         
         return distribution_config
-`
+```
 
 ### 静的コンテンツから動的コンテンツへ
 
 **静的コンテンツの最適化**
 
-`python
+```python
 class StaticContentOptimization:
     """
     静的コンテンツの最適化
@@ -3671,11 +3671,11 @@ class StaticContentOptimization:
         ]
         
         return cache_behaviors
-`
+```
 
 **動的コンテンツの加速**
 
-`python
+```python
 class DynamicContentAcceleration:
     """
     動的コンテンツの加速
@@ -3832,13 +3832,13 @@ class DynamicContentAcceleration:
             'edge_computing': edge_functions,
             'example': edge_function_example
         }
-`
+```
 
 ### キャッシュ戦略の設計
 
 **インテリジェントなキャッシュ管理**
 
-`python
+```python
 class CacheStrategyDesign:
     """
     キャッシュ戦略の設計
@@ -3982,13 +3982,13 @@ class CacheStrategyDesign:
         }
         
         return cache_warming
-`
+```
 
 ### セキュリティ機能の活用
 
 **包括的なセキュリティ実装**
 
-`python
+```python
 class CDNSecurity:
     """
     CDNセキュリティの実装
@@ -4124,13 +4124,13 @@ class CDNSecurity:
         }
         
         return ddos_protection
-`
+```
 
 ### パフォーマンス最適化
 
 **包括的な最適化戦略**
 
-`python
+```python
 class CDNPerformanceOptimization:
     """
     CDNパフォーマンス最適化
@@ -4267,13 +4267,13 @@ class CDNPerformanceOptimization:
             'monitoring': monitoring_config,
             'dashboard': dashboard_config
         }
-`
+```
 
 ### マルチCDN戦略
 
 **冗長性とパフォーマンスの最適化**
 
-`python
+```python
 class MultiCDNStrategy:
     """
     マルチCDN戦略の実装
@@ -4379,7 +4379,7 @@ class MultiCDNStrategy:
         """
         
         return selection_logic
-`
+```
 
 ## まとめ
 


### PR DESCRIPTION
Stage3（表現・スタイル/記号）として、`docs` 側のコードブロック表示崩れを修正します。

- 対象: `docs/chapter-chapter05/index.md`
- 変更内容: `` `python `` / `` ` `` になっていたフェンスを、Markdownの正しいコードフェンス（```python / ```）へ修正
- 目的: サンプルコードがコードブロックとしてレンダリングされ、読み進めやすくする
