### PR TITLE
docs: make OS example less version-stale

### DIFF
--- a/docs/chapter-chapter03/index.md
+++ b/docs/chapter-chapter03/index.md
@@ -575,7 +575,7 @@ License Included：
 ```
 推奨構成：
 - インスタンスタイプ: m6i.large
-- OS: Ubuntu 20.04 LTS
+- OS: Ubuntu LTS（例: 22.04）
 - 配置: 複数AZでの冗長化
 - ロードバランサー: Application Load Balancer
 


### PR DESCRIPTION
品質スプリント（it-engineer-knowledge-architecture#105）対応。

章内の推奨構成例で Ubuntu 20.04 LTS を固定で記載していたため、陳腐化しにくい表現（Ubuntu LTSの例示）に更新しました。

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/105