### PR TITLE
Ubuntu LTS例を更新（22.04）

### DIFF
--- a/src/chapter-chapter03/index.md
+++ b/src/chapter-chapter03/index.md
@@ -574,7 +574,7 @@ License Included：
 ```
 推奨構成：
 - インスタンスタイプ: m6i.large
-- OS: Ubuntu 20.04 LTS
+- OS: Ubuntu LTS（例: 22.04）
 - 配置: 複数AZでの冗長化
 - ロードバランサー: Application Load Balancer
 


### PR DESCRIPTION
 の Ubuntu バージョン例が 20.04 LTS になっていたため、 と同じ表記（Ubuntu LTS 例: 22.04）に揃えました。