### PR TITLE
docs: update base image examples (Ubuntu 22.04/24.04, AL2023)

### DIFF
--- a/docs/chapter-chapter06/index.md
+++ b/docs/chapter-chapter06/index.md
@@ -5642,8 +5642,9 @@ class ContainerSecurity:
             'base_image_policy': {
                 'allowed_base_images': [
                     'alpine:latest',
-                    'ubuntu:20.04',
-                    'amazonlinux:2'
+                    'ubuntu:22.04',
+                    'ubuntu:24.04',
+                    'amazonlinux:2023'
                 ],
                 'prohibited_packages': [
                     'netcat',

--- a/src/chapter-chapter06/index.md
+++ b/src/chapter-chapter06/index.md
@@ -5635,8 +5635,9 @@ class ContainerSecurity:
             'base_image_policy': {
                 'allowed_base_images': [
                     'alpine:latest',
-                    'ubuntu:20.04',
-                    'amazonlinux:2'
+                    'ubuntu:22.04',
+                    'ubuntu:24.04',
+                    'amazonlinux:2023'
                 ],
                 'prohibited_packages': [
                     'netcat',


### PR DESCRIPTION
## 変更内容\n- 章内の許容ベースイメージ例を更新\n  - Ubuntu: 20.04 -> 22.04/24.04\n  - Amazon Linux: 2 -> 2023\n\n## 背景\n- 『20.04向け手順は削除して22.04/24.04のみ残す』『Amazon Linux 2023版とする』方針に合わせる。\n\n## 影響範囲\n- ドキュメント記述のみ（動作ロジック変更なし）\n\n## 確認\n- Book QA/CI にて確認