### PR TITLE
fix(docs): update Python container base image

### DIFF
--- a/docs/chapter-chapter09/index.md
+++ b/docs/chapter-chapter09/index.md
@@ -511,7 +511,7 @@ CMD ["node", "dist/server.js"]
 # 変更頻度: 低 → 高
 
 # 1. ベースイメージ（めったに変更されない）
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 # 2. システムパッケージ（たまに変更）
 RUN apt-get update && apt-get install -y \

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -511,7 +511,7 @@ CMD ["node", "dist/server.js"]
 # 変更頻度: 低 → 高
 
 # 1. ベースイメージ（めったに変更されない）
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 # 2. システムパッケージ（たまに変更）
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## 変更内容
- サンプル Dockerfile の Python ベースイメージを更新
  - `python:3.9-slim` → `python:3.11-slim`

## 背景
- Python 3.9 はサポート終了（EOL）のため、例示のベースイメージを更新します。

## 影響範囲
- 本文（サンプルのイメージタグ）のみ
