### PR TITLE
CI記述例の GitHub Actions バージョンを v4 に更新

### DIFF
--- a/docs/chapter-chapter09/index.md
+++ b/docs/chapter-chapter09/index.md
@@ -1343,13 +1343,13 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@v7
         env:
           GITHUB_TOKEN: `{% raw %}`${{ secrets.GITHUB_TOKEN }}`{% endraw %}`
           SONAR_TOKEN: `{% raw %}`${{ secrets.SONAR_TOKEN }}`{% endraw %}`
           
       - name: Check Quality Gate
-        uses: sonarsource/sonarqube-quality-gate-action@master
+        uses: sonarsource/sonarqube-quality-gate-action@v1
         timeout-minutes: 5
         env:
           SONAR_TOKEN: `{% raw %}`${{ secrets.SONAR_TOKEN }}`{% endraw %}`

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -1343,13 +1343,13 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@v7
         env:
           GITHUB_TOKEN: {% raw %}`${{ secrets.GITHUB_TOKEN }}`{% endraw %}
           SONAR_TOKEN: {% raw %}`${{ secrets.SONAR_TOKEN }}`{% endraw %}
           
       - name: Check Quality Gate
-        uses: sonarsource/sonarqube-quality-gate-action@master
+        uses: sonarsource/sonarqube-quality-gate-action@v1
         timeout-minutes: 5
         env:
           SONAR_TOKEN: {% raw %}`${{ secrets.SONAR_TOKEN }}`{% endraw %}


### PR DESCRIPTION
Issue #102 の残作業（非推奨記述の棚卸し）対応です。

- 章内の CI 記述例で `actions/checkout@v3` を `actions/checkout@v4` に更新
- `src` / `docs` の重複管理ファイルを同期更新
