### PR TITLE
CI記述例の @master 参照をバージョンタグへ更新

### DIFF
--- a/docs/chapter-chapter09/index.md
+++ b/docs/chapter-chapter09/index.md
@@ -1389,7 +1389,7 @@ jobs:
           outputs: type=docker,dest=/tmp/image.tar
           
       - name: Run Trivy Scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           input: /tmp/image.tar
           format: 'sarif'

--- a/docs/chapter-chapter10/index.md
+++ b/docs/chapter-chapter10/index.md
@@ -1630,7 +1630,7 @@ jobs:
       
       - name: Checkov Security Scan
         id: checkov
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@v12.3080.0
         with:
           directory: terraform/
           framework: terraform

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -1389,7 +1389,7 @@ jobs:
           outputs: type=docker,dest=/tmp/image.tar
           
       - name: Run Trivy Scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           input: /tmp/image.tar
           format: 'sarif'

--- a/src/chapter-chapter10/index.md
+++ b/src/chapter-chapter10/index.md
@@ -1625,7 +1625,7 @@ jobs:
       
       - name: Checkov Security Scan
         id: checkov
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@v12.3080.0
         with:
           directory: terraform/
           framework: terraform


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例に残っている @master 参照を、明示バージョンタグへ更新

## 変更内容
- aquasecurity/trivy-action@master -> aquasecurity/trivy-action@0.33.1
- bridgecrewio/checkov-action@master -> bridgecrewio/checkov-action@v12.3080.0

## 補足
- 本PRは、当該リポジトリに実在する該当記述のみを更新しています。
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102