### PR TITLE
CI記述例の codeql-action 参照を v4 に更新

### DIFF
--- a/docs/chapter-chapter09/index.md
+++ b/docs/chapter-chapter09/index.md
@@ -1397,7 +1397,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           
       - name: Upload Trivy Results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
           

--- a/docs/chapter-chapter10/index.md
+++ b/docs/chapter-chapter10/index.md
@@ -1638,7 +1638,7 @@ jobs:
           output_file_path: reports/checkov.sarif
           
       - name: Upload Checkov results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: reports/checkov.sarif

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -1397,7 +1397,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           
       - name: Upload Trivy Results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
           

--- a/src/chapter-chapter10/index.md
+++ b/src/chapter-chapter10/index.md
@@ -1633,7 +1633,7 @@ jobs:
           output_file_path: reports/checkov.sarif
           
       - name: Upload Checkov results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: reports/checkov.sarif


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例に残る `github/codeql-action@v2` 系参照を `@v4` に更新

## 変更内容
- `github/codeql-action/init@v2` -> `@v4`
- `github/codeql-action/analyze@v2` -> `@v4`
- `github/codeql-action/upload-sarif@v2` -> `@v4`
- `github/codeql-action/autobuild@v2` -> `@v4`

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
