### PR TITLE
CI記述例の Docker Actions 参照を v3 に更新

### DIFF
--- a/docs/chapter-chapter09/index.md
+++ b/docs/chapter-chapter09/index.md
@@ -1376,7 +1376,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         
       - name: Build Image
         uses: docker/build-push-action@v4

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -1376,7 +1376,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         
       - name: Build Image
         uses: docker/build-push-action@v4


### PR DESCRIPTION
## 概要
- 書籍本文の Docker 関連 GitHub Actions 記述例で、`docker/setup-buildx-action` の参照を `@v2` から `@v3` に更新

## 変更内容
- `docker/setup-buildx-action@v2` -> `docker/setup-buildx-action@v3`

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102