### PR TITLE
CI記述例の Terraform/AWS Actions 参照を更新

### DIFF
--- a/docs/chapter-chapter09/index.md
+++ b/docs/chapter-chapter09/index.md
@@ -1366,14 +1366,14 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: `{% raw %}`${{ secrets.AWS_ROLE_ARN }}`{% endraw %}`
           aws-region: ap-northeast-1
           
       - name: Login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -1437,7 +1437,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: `{% raw %}`${{ secrets.AWS_PROD_ROLE_ARN }}`{% endraw %}`
           aws-region: ap-northeast-1

--- a/docs/chapter-chapter10/index.md
+++ b/docs/chapter-chapter10/index.md
@@ -1580,7 +1580,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: `{% raw %}`${{ env.TF_VERSION }}`{% endraw %}`
           
@@ -1707,7 +1707,7 @@ jobs:
           aws-region: `{% raw %}`${{ env.AWS_REGION }}`{% endraw %}`
           
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: `{% raw %}`${{ env.TF_VERSION }}`{% endraw %}`
           
@@ -1812,7 +1812,7 @@ jobs:
           aws-region: `{% raw %}`${{ env.AWS_REGION }}`{% endraw %}`
           
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: `{% raw %}`${{ env.TF_VERSION }}`{% endraw %}`
           

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -1366,14 +1366,14 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: {% raw %}`${{ secrets.AWS_ROLE_ARN }}`{% endraw %}
           aws-region: ap-northeast-1
           
       - name: Login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -1437,7 +1437,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: {% raw %}`${{ secrets.AWS_PROD_ROLE_ARN }}`{% endraw %}
           aws-region: ap-northeast-1

--- a/src/chapter-chapter10/index.md
+++ b/src/chapter-chapter10/index.md
@@ -1575,7 +1575,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: `${{ env.TF_VERSION }}`
           
@@ -1702,7 +1702,7 @@ jobs:
           aws-region: `${{ env.AWS_REGION }}`
           
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: `${{ env.TF_VERSION }}`
           
@@ -1807,7 +1807,7 @@ jobs:
           aws-region: `${{ env.AWS_REGION }}`
           
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: `${{ env.TF_VERSION }}`
           


### PR DESCRIPTION
## 概要
- 書籍本文のクラウド/IaC系 GitHub Actions 記述例で、旧バージョン参照を更新

## 変更内容
- `hashicorp/setup-terraform@v1|v2` -> `hashicorp/setup-terraform@v3`
- `aws-actions/configure-aws-credentials@v1|v2` -> `aws-actions/configure-aws-credentials@v4`
- `aws-actions/amazon-ecr-login@v1` -> `aws-actions/amazon-ecr-login@v2`

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
