### PR TITLE
CI記述例の追加Action参照を更新

### DIFF
--- a/docs/chapter-chapter10/index.md
+++ b/docs/chapter-chapter10/index.md
@@ -1598,7 +1598,7 @@ jobs:
           done
           
       - name: TFLint
-        uses: terraform-linters/setup-tflint@v3
+        uses: terraform-linters/setup-tflint@v6
         with:
           tflint_version: latest
           

--- a/src/chapter-chapter10/index.md
+++ b/src/chapter-chapter10/index.md
@@ -1593,7 +1593,7 @@ jobs:
           done
           
       - name: TFLint
-        uses: terraform-linters/setup-tflint@v3
+        uses: terraform-linters/setup-tflint@v6
         with:
           tflint_version: latest
           


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例で、旧参照を更新

## 変更内容
- terraform-linters/setup-tflint@v6

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
