### PR TITLE
docs: actions/setup-python を v6 に更新

### DIFF
--- a/docs/chapter-chapter10/index.md
+++ b/docs/chapter-chapter10/index.md
@@ -1609,7 +1609,7 @@ jobs:
           tflint --recursive
           
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           
@@ -1848,7 +1848,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           

--- a/src/chapter-chapter10/index.md
+++ b/src/chapter-chapter10/index.md
@@ -1604,7 +1604,7 @@ jobs:
           tflint --recursive
           
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           
@@ -1843,7 +1843,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           


### PR DESCRIPTION
- `docs/src` の章10内Workflow例で `actions/setup-python@v4` を `@v6` に更新
- 変更範囲はドキュメントのWorkflow例のみ

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102