### PR TITLE
docs: docker/build-push-action の例を v6 に更新

### DIFF
--- a/docs/chapter-chapter09/index.md
+++ b/docs/chapter-chapter09/index.md
@@ -1379,7 +1379,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         
       - name: Build Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -1379,7 +1379,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         
       - name: Build Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false


### PR DESCRIPTION
## 概要
- ドキュメント/サンプル内の `docker/build-push-action@v4` を `@v6` に更新
- 参照先を最新メジャー（`docker/build-push-action` latest: `v6.19.1`）へ追随

## 変更
- `docker/build-push-action@v4` -> `docker/build-push-action@v6`

Closes #102