### PR TITLE
[codex] Clarify cloud infra README feedback links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@
 ## オンライン版（入口）
 
 - リポジトリ内: `docs/index.md`
-- GitHub Pages を有効化している場合: https://itdojp.github.io/cloud-infra-book/
+- GitHub Pages を有効化している場合: [クラウドインフラ設計・構築ガイド](https://itdojp.github.io/cloud-infra-book/)
 
 ## フィードバック
 
-- Issue: https://github.com/itdojp/cloud-infra-book/issues
+- Issue: [itdojp/cloud-infra-book の Issues](https://github.com/itdojp/cloud-infra-book/issues)
 
 ## ライセンス
 


### PR DESCRIPTION
## Summary
- convert bare feedback URLs in `README.md` to Markdown links
- keep the feedback section reader-facing and consistent

## Testing
- npx --yes markdownlint-cli README.md
- git diff --check