### PR TITLE
Fix mobile sidebar closed state

### DIFF
--- a/cloud-infra-book/docs/assets/css/mobile-responsive.css
+++ b/cloud-infra-book/docs/assets/css/mobile-responsive.css
@@ -49,7 +49,14 @@ html {
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
     z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -54,7 +54,14 @@ html {
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
     z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 


### PR DESCRIPTION
## Summary
- keep the closed mobile/tablet sidebar drawer off-canvas with `!important` so the later desktop `.book-sidebar { transform: translateX(0); }` rule in `main.css` cannot override it
- apply the same fix to both tracked published CSS copies under `docs/` and the nested tracked copy
- leave the checked/open drawer rule unchanged so the hamburger menu still opens the TOC

Context: itdojp/it-engineer-knowledge-architecture#168

## Verification
- `npm ci`
- `npm test`
- `cd docs && BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/cloud-infra-docs-bundle-path BUNDLE_APP_CONFIG=/home/devuser/work/CodeX/booksB/.codex-local/tmp/cloud-infra-docs-bundle-config bundle exec jekyll build`
- `git diff --check`
- local Pages visual check with Chromium: `books=1 pages=10 ok=10 warn=0 fail=0`
- direct Playwright probe over `/` and `/chapter-chapter01/` at 480/768/820/1024/1280 confirmed the closed drawer is off-canvas on <=1024px, the toggle opens it, and desktop layout remains visible

## Notes
- `npm run build` without `bundle exec` hits a local Ruby activated-spec conflict after bundle installation (`rake` 13.3.1 already activated vs Gemfile 13.4.2).
- `npm run build:safe` reaches an existing root-source Liquid conflict in `src/chapter-chapter04/index.md`; this PR does not modify that file. The actual GitHub Pages source for this repo is `/docs`, and the `/docs` Jekyll build passed.
