### PR TITLE
docs: protect Azure Files example from Liquid

### DIFF
--- a/src/chapter-chapter04/index.md
+++ b/src/chapter-chapter04/index.md
@@ -1756,6 +1756,7 @@ df -h | grep {mount_point}
 
 Windows環境での標準プロトコル：
 
+{% raw %}
 ```python
 class SMBImplementation:
     """
@@ -1842,6 +1843,7 @@ findmnt "$MOUNTPOINT"
         }
 
 ```
+{% endraw %}
 
 ### パフォーマンスとスケーラビリティ
 


### PR DESCRIPTION
## 変更

src/chapter-chapter04/index.md のAzure Files用Python f-stringコードブロックをLiquid raw/endrawで囲み、公開docs側の既存表現と一致させた。

## 原因

root Jekyll buildがPython f-stringの二重波括弧をLiquid変数として解釈し、Variable was not properly terminatedで失敗していた。

## 検証

- npm ci
- npm test
- npm run build:safe
- npm audit --omit=dev --omit=optional: 0
- git diff --check

full npm auditの既存dev依存4件は #140 で分離追跡する。

Closes #139
Discovered during: itdojp/it-engineer-knowledge-architecture#211
