### PR TITLE
fix: 公開内容にUX module metadataを合わせる

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -85,12 +85,12 @@
     "modules": {
       "quickStart": false,
       "readingGuide": true,
-      "checklistPack": false,
+      "checklistPack": true,
       "troubleshootingFlow": false,
       "conceptMap": false,
       "figureIndex": false,
       "legalNotice": true,
-      "glossary": false
+      "glossary": true
     }
   },
   "shared": {


### PR DESCRIPTION
## 概要

公開中の読者向け付録・導線に合わせて `book-config.json` の UX module metadata を補正します。

- `checklistPack`: `false` → `true`（付録Cの設計・セキュリティ・運用チェックリスト）
- `glossary`: `false` → `true`（付録Dの用語集）
- それ以外のUX moduleは変更しません

## 検証

- `npm ci`
- `npm test`
- `npm run build:safe`
- `npm audit --omit=dev --omit=optional`（0 vulnerabilities）
- `git diff --check`

`npm ci` の全依存監査で表示される既存dev依存の4件は #140 で分離して追跡します。

Closes #138
