### PR TITLE
chore: active workflowsをNode.js 24対応Actionへ更新

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -86,7 +86,7 @@ jobs:
           path: ${{ runner.temp }}/layout-risk-report.json
           if-no-files-found: ignore
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build (Jekyll; GitHub Pages compatible)
         uses: actions/jekyll-build-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
           
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         
       - name: Build with Jekyll
         run: |


### PR DESCRIPTION
## Summary
- Book QAとPages workflowの`actions/configure-pages`を`v5`からNode.js 24 runtime対応の`v6`へ更新
- workflow入力、permissions、Jekyll build/deploy契約は維持
- active workflow内の対象旧参照を0件化

## Verification
- actionlint 1.7.12（変更2 workflow）: PASS
- `npm ci`: PASS
- `npm audit`: 0 vulnerabilities
- `npm test`: PASS
- `bundle exec jekyll build --source docs --destination docs/_site`: PASS
- `git diff --check`: PASS
- 旧`configure-pages@v5`: 0 / 新`configure-pages@v6`: 2

Closes #146
