### PR TITLE
chore: remaining Pages actionsをNode.js 24対応へ更新

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
           JEKYLL_ENV: production
           
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./docs/_site
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- main Pages run 29361241212で残存したNode.js 20 warningを解消
- `actions/upload-pages-artifact`を`v4`から`v5`へ更新
- `actions/deploy-pages`を`v4`から`v5`へ更新
- PR #147で反映済みの`configure-pages@v6`と合わせ、active workflowのNode.js 20以前Actionを0件化

## Verification
- actionlint 1.7.12（Book QA / Pages workflow）: PASS
- upstream Action metadataでupload/deployの入力契約維持を確認
- `npm ci`: PASS
- `npm audit`: 0 vulnerabilities
- `npm test`: PASS
- Jekyll build: PASS
- `git diff --check`: PASS
- active workflow旧参照: configure v5 / upload-pages v4 / deploy-pages v4 = 0
- 新参照: configure v6 = 2 / upload-pages v5 = 1 / deploy-pages v5 = 1

## Separated debt
- npmの`whatwg-encoding@3.1.1` warningは#148で追跡

Closes #146
